### PR TITLE
[feat] Add projectId and groupId to event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,6 +5528,7 @@ dependencies = [
  "orml-traits",
  "pallet-assets",
  "pallet-balances",
+ "pallet-carbon-credits",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/pallets/carbon-credits/src/lib.rs
+++ b/pallets/carbon-credits/src/lib.rs
@@ -571,10 +571,14 @@ pub mod pallet {
 }
 
 /// Struct to verify if a given asset_id is representing a carbon credit project
-pub struct CarbonCreditsAssetValidator<T>(sp_std::marker::PhantomData<T>);
-impl<T: Config> Contains<T::AssetId> for CarbonCreditsAssetValidator<T> {
-	// Returns true if the AssetId represents a CarbonCredits project
-	fn contains(asset_id: &T::AssetId) -> bool {
-		AssetIdLookup::<T>::contains_key(asset_id)
+impl<T: Config> primitives::CarbonCreditsValidator for Pallet<T> {
+	type ProjectId = T::ProjectId;
+
+	type GroupId = T::GroupId;
+
+	type AssetId = T::AssetId;
+
+	fn get_project_details(asset_id: &Self::AssetId) -> Option<(Self::ProjectId, Self::GroupId)> {
+		AssetIdLookup::<T>::get(asset_id)
 	}
 }

--- a/pallets/dex/Cargo.toml
+++ b/pallets/dex/Cargo.toml
@@ -16,22 +16,23 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 	"derive",
 ] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "4.0.0-dev", default-features = false, optional = true,  git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33"  }
-frame-support = { version = "4.0.0-dev", default-features = false,  git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
-frame-system = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
-sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
+frame-benchmarking = { default-features = false, optional = true,  git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33"  }
+frame-support = { default-features = false,  git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.33" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.33" }
+pallet-carbon-credits = { package = 'pallet-carbon-credits', path = '../carbon-credits', default-features = false }
 
 # Local dependencies
 pallet-assets = { package = 'pallet-assets', path = '../assets', default-features = false }
 primitives = { package = 'bitgreen-primitives', path = '../../primitives', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
-sp-io = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.33" }
 
 [features]
 default = ["std"]
@@ -45,7 +46,8 @@ std = [
 	"sp-std/std",
 	"pallet-balances/std",
 	"primitives/std",
-	"orml-tokens/std"
+	"orml-tokens/std",
+	"pallet-carbon-credits/std"
 ]
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/dex/src/lib.rs
+++ b/pallets/dex/src/lib.rs
@@ -58,14 +58,12 @@ pub mod pallet {
 	use crate::{OrderId, OrderInfo, WeightInfo};
 	use frame_support::{
 		pallet_prelude::*,
-		traits::{
-			fungibles::{Inspect, Transfer},
-			Contains,
-		},
+		traits::fungibles::{Inspect, Transfer},
 		transactional, PalletId,
 	};
 	use frame_system::pallet_prelude::{OriginFor, *};
 	use orml_traits::MultiCurrency;
+	use primitives::CarbonCreditsValidator;
 	use sp_runtime::{
 		traits::{AccountIdConversion, AtLeast32BitUnsigned, CheckedSub, One, Zero},
 		Percent,
@@ -87,6 +85,10 @@ pub mod pallet {
 
 	pub type AssetIdOf<T> =
 		<<T as Config>::Asset as Inspect<<T as frame_system::Config>::AccountId>>::AssetId;
+
+	pub type ProjectIdOf<T> = <<T as Config>::AssetValidator as CarbonCreditsValidator>::ProjectId;
+
+	pub type GroupIdOf<T> = <<T as Config>::AssetValidator as CarbonCreditsValidator>::GroupId;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
 	#[pallet::config]
@@ -126,7 +128,7 @@ pub mod pallet {
 		type ForceOrigin: EnsureOrigin<Self::RuntimeOrigin>;
 
 		/// Verify if the asset can be listed on the dex
-		type AssetValidator: Contains<AssetIdOf<Self>>;
+		type AssetValidator: CarbonCreditsValidator<AssetId = AssetIdOf<Self>>;
 
 		/// The CurrencyId of the stable currency we accept as payment
 		#[pallet::constant]
@@ -192,6 +194,8 @@ pub mod pallet {
 		SellOrderCreated {
 			order_id: OrderId,
 			asset_id: AssetIdOf<T>,
+			project_id: ProjectIdOf<T>,
+			group_id: GroupIdOf<T>,
 			units: AssetBalanceOf<T>,
 			price_per_unit: CurrencyBalanceOf<T>,
 			owner: T::AccountId,
@@ -202,6 +206,8 @@ pub mod pallet {
 		BuyOrderFilled {
 			order_id: OrderId,
 			units: AssetBalanceOf<T>,
+			project_id: ProjectIdOf<T>,
+			group_id: GroupIdOf<T>,
 			price_per_unit: CurrencyBalanceOf<T>,
 			seller: T::AccountId,
 			buyer: T::AccountId,
@@ -255,7 +261,8 @@ pub mod pallet {
 			let seller = ensure_signed(origin.clone())?;
 
 			// ensure the asset_id can be listed
-			ensure!(T::AssetValidator::contains(&asset_id), Error::<T>::AssetNotPermitted);
+			let (project_id, group_id) = T::AssetValidator::get_project_details(&asset_id)
+				.ok_or(Error::<T>::AssetNotPermitted)?;
 
 			// ensure minimums are satisfied
 			ensure!(units >= T::MinUnitsToCreateSellOrder::get(), Error::<T>::BelowMinimumUnits);
@@ -278,6 +285,8 @@ pub mod pallet {
 			Self::deposit_event(Event::SellOrderCreated {
 				order_id,
 				asset_id,
+				project_id,
+				group_id,
 				units,
 				price_per_unit,
 				owner: seller,
@@ -338,6 +347,10 @@ pub mod pallet {
 				// ensure volume remaining can cover the buy order
 				ensure!(units <= order.units, Error::<T>::OrderUnitsOverflow);
 
+				// get the projectId and groupId for events
+				let (project_id, group_id) = T::AssetValidator::get_project_details(&asset_id)
+					.ok_or(Error::<T>::AssetNotPermitted)?;
+
 				// reduce the buy_order units from total volume
 				order.units =
 					order.units.checked_sub(&units).ok_or(Error::<T>::OrderUnitsOverflow)?;
@@ -383,6 +396,8 @@ pub mod pallet {
 				Self::deposit_event(Event::BuyOrderFilled {
 					order_id,
 					units,
+					project_id,
+					group_id,
 					price_per_unit: order.price_per_unit,
 					seller: order.owner.clone(),
 					buyer,

--- a/pallets/dex/src/lib.rs
+++ b/pallets/dex/src/lib.rs
@@ -158,11 +158,6 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 	}
 
-	// owner of swap pool
-	#[pallet::storage]
-	#[pallet::getter(fn owner)]
-	pub type Owner<T: Config> = StorageValue<_, T::AccountId>;
-
 	// orders information
 	#[pallet::storage]
 	#[pallet::getter(fn order_count)]
@@ -209,6 +204,7 @@ pub mod pallet {
 			project_id: ProjectIdOf<T>,
 			group_id: GroupIdOf<T>,
 			price_per_unit: CurrencyBalanceOf<T>,
+			fees_paid: CurrencyBalanceOf<T>,
 			seller: T::AccountId,
 			buyer: T::AccountId,
 		},
@@ -399,6 +395,7 @@ pub mod pallet {
 					project_id,
 					group_id,
 					price_per_unit: order.price_per_unit,
+					fees_paid: required_fees.into(),
 					seller: order.owner.clone(),
 					buyer,
 				});

--- a/pallets/dex/src/mock.rs
+++ b/pallets/dex/src/mock.rs
@@ -3,13 +3,13 @@
 // This code is licensed under MIT license (see LICENSE.txt for details)
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, Contains, Everything, GenesisBuild, Nothing},
+	traits::{AsEnsureOriginWithArg, ConstU32, Everything, GenesisBuild, Nothing},
 	PalletId,
 };
 use frame_system as system;
 use frame_system::EnsureRoot;
 use orml_traits::parameter_type_with_key;
-use primitives::{Amount, Balance, CurrencyId};
+use primitives::{Amount, Balance, CarbonCreditsValidator, CurrencyId};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -135,9 +135,12 @@ impl orml_tokens::Config for Test {
 }
 
 pub struct DummyValidator;
-impl Contains<u32> for DummyValidator {
-	fn contains(_asset_id: &u32) -> bool {
-		true
+impl CarbonCreditsValidator for DummyValidator {
+	type ProjectId = u32;
+	type AssetId = u32;
+	type GroupId = u32;
+	fn get_project_details(_asset_id: &Self::AssetId) -> Option<(Self::ProjectId, Self::GroupId)> {
+		Some((0, 0))
 	}
 }
 

--- a/pallets/dex/src/tests.rs
+++ b/pallets/dex/src/tests.rs
@@ -35,6 +35,8 @@ fn basic_create_sell_order_should_work() {
 			Event::SellOrderCreated {
 				order_id: 0,
 				asset_id,
+				project_id: 0,
+				group_id: 0,
 				units: 5,
 				price_per_unit: 1,
 				owner: seller
@@ -232,8 +234,16 @@ fn buy_order_should_work() {
 
 		assert_eq!(
 			last_event(),
-			Event::BuyOrderFilled { order_id: 0, units: 1, price_per_unit: 10, seller, buyer }
-				.into()
+			Event::BuyOrderFilled {
+				order_id: 0,
+				units: 1,
+				price_per_unit: 10,
+				seller,
+				buyer,
+				project_id: 0,
+				group_id: 0,
+			}
+			.into()
 		);
 	});
 }

--- a/pallets/dex/src/tests.rs
+++ b/pallets/dex/src/tests.rs
@@ -240,7 +240,7 @@ fn buy_order_should_work() {
 				price_per_unit: 10,
 				seller,
 				buyer,
-				fees_paid: 0u128,
+				fees_paid: 11u128,
 				project_id: 0,
 				group_id: 0,
 			}

--- a/pallets/dex/src/tests.rs
+++ b/pallets/dex/src/tests.rs
@@ -240,6 +240,7 @@ fn buy_order_should_work() {
 				price_per_unit: 10,
 				seller,
 				buyer,
+				fees_paid: 0u128,
 				project_id: 0,
 				group_id: 0,
 			}

--- a/primitives/src/carbon_credits.rs
+++ b/primitives/src/carbon_credits.rs
@@ -1,6 +1,7 @@
 use super::*;
 use frame_support::{pallet_prelude::Get, BoundedVec};
 pub type IssuanceYear = u16;
+use sp_std::fmt::Debug;
 
 /// The possible values for Registry Names
 #[derive(Clone, Encode, Decode, Eq, PartialEq, Debug, TypeInfo, MaxEncodedLen)]
@@ -159,4 +160,19 @@ pub struct BatchGroup<StringType, AssetId, Balance, Batch, MaxBatches: Get<u32>>
 	/// originator mints 100 tokens, we first mint the oldest (2019) credits and only once the
 	/// supply is exhausted we move on the next vintage, same for retirement.
 	pub batches: BoundedVec<Batch, MaxBatches>,
+}
+
+/// Trait to identify details of carbon credits
+pub trait CarbonCreditsValidator {
+	/// ProjectId type representing the project
+	type ProjectId: Clone + PartialEq + Debug;
+
+	/// GroupId type representing the group
+	type GroupId: Clone + PartialEq + Debug;
+
+	/// AssetId type representing the asset
+	type AssetId: Clone + PartialEq + Debug;
+
+	/// Returns ProjectId and GroupId if the given AssetId represents a CarbonCredit Project
+	fn get_project_details(asset_id: &Self::AssetId) -> Option<(Self::ProjectId, Self::GroupId)>;
 }

--- a/runtime/bitgreen/src/lib.rs
+++ b/runtime/bitgreen/src/lib.rs
@@ -737,7 +737,7 @@ impl pallet_dex::Config for Runtime {
 	type AssetBalance = u128;
 	type StableCurrencyId = StableCurrencyId;
 	type PalletId = DexPalletId;
-	type AssetValidator = pallet_carbon_credits::CarbonCreditsAssetValidator<Runtime>;
+	type AssetValidator = CarbonCredits;
 	type MinPricePerUnit = MinPricePerUnit;
 	type MinUnitsToCreateSellOrder = MinUnitsToCreateSellOrder;
 	type ForceOrigin = EnsureRoot<AccountId>;

--- a/runtime/rococo/src/lib.rs
+++ b/runtime/rococo/src/lib.rs
@@ -761,7 +761,7 @@ impl pallet_dex::Config for Runtime {
 	type AssetBalance = u128;
 	type StableCurrencyId = StableCurrencyId;
 	type PalletId = DexPalletId;
-	type AssetValidator = pallet_carbon_credits::CarbonCreditsAssetValidator<Runtime>;
+	type AssetValidator = CarbonCredits;
 	type MinPricePerUnit = MinPricePerUnit;
 	type MinUnitsToCreateSellOrder = MinUnitsToCreateSellOrder;
 	type ForceOrigin = EnsureRoot<AccountId>;


### PR DESCRIPTION
Changelog:
Add projectId and groupId to the sellOrderCreated and buyOrder events, this helps the frontend identify the project without additional queries.